### PR TITLE
Add comment line for example groups

### DIFF
--- a/lib/rspec_tap/formatter.rb
+++ b/lib/rspec_tap/formatter.rb
@@ -15,6 +15,13 @@ module RspecTap
       super(stdout)
     end
 
+    def example_group_started(notification)
+      super
+      group = notification.group.to_s.gsub('::', '.')
+      group = group.gsub(/^rspec\.examplegroups\.?/i, '')
+      output.puts "# " + group
+    end
+
     def example_started(notification)
       @progress_count += 1
     end


### PR DESCRIPTION
Some Tap formatters, like [tap-xunit](https://github.com/aghassemi/tap-xunit/blob/master/lib/converter.js#L41), use comments in order to delineate groups of assertions.  I felt this was a good spot to add info about the example groups.

This produces TAP output like the following:
```

Randomized with seed 55555
1..999
# API
# API.FooController
ok 1 - API FooController get root is successful
ok 2 - API FooController put root does something
# API.BarController
ok 3 - API BarController get with ID is successful
```